### PR TITLE
Add $.balanceText(elementsOrSelector) for continuous updates

### DIFF
--- a/jquery.balancetext.js
+++ b/jquery.balancetext.js
@@ -266,27 +266,36 @@
         return (h / spaceRatio);
     };
 
-    // Selectors to watch; calling balanceText() on a new selector adds it to this list.
-    var balancedElements = ['.balance-text'];
+    // Selectors and elements to watch;
+    // calling $.balanceText(elements) adds "elements" to this list.
+    var watching = {
+        sel: ['.balance-text'], // default class to watch
+        $el: $()
+    };
 
-    // Call the balanceText plugin on the elements with "balance-text" class. When a browser
-    // has native support for the text-wrap property, the text balanceText plugin will let
-    // the browser handle it natively, otherwise it will apply its own text balancing code.
+    // Call the balanceText plugin on elements that it's watching.
     var applyBalanceText = function () {
-        var selector = balancedElements.join(',');
-        $(selector).balanceText(true);
+        watching.$el
+            .add(watching.sel.join(','))
+            .balanceText();
     };
 
     $.fn.balanceTextUpdate = applyBalanceText;
 
-    $.fn.balanceText = function (skipResize) {
-        var selector = this.selector;
-
-        if (!skipResize && selector && balancedElements.indexOf(selector) === -1) {
-            // record the selector so we can re-balance it on resize
-            balancedElements.push(selector);
+    // Watch elements or a selector for the next updates
+    $.balanceText = function (elements) {
+        if (typeof elements === 'string') {
+            watching.sel.push(elements);
+        } else {
+            watching.$el = watching.$el.add(elements);
         }
+        $(elements).balanceText();
+    };
 
+    // When a browser has native support for the text-wrap property,
+    // the text balanceText plugin will let the browser handle it natively,
+    // otherwise it will apply its own text balancing code.
+    $.fn.balanceText = function () {
         if (hasTextWrap) {
             // browser supports text-wrap, so do nothing
             return this;
@@ -350,9 +359,7 @@
                     // clear whitespace match cache for each line
                     wsMatches = null;
 
-                    var desiredWidth = Math.round((nowrapWidth + spaceWidth)
-                                                  / remLines
-                                                  - spaceWidth);
+                    var desiredWidth = Math.round((nowrapWidth + spaceWidth) / remLines - spaceWidth);
 
                     // Guessed char index
                     var guessIndex = Math.round((remainingText.length + 1) / remLines) - 1;

--- a/test/test1.htm
+++ b/test/test1.htm
@@ -14,7 +14,9 @@
 
 <style type="text/css">
 /* Apply (proposed) CSS style. Plugin looks for elements with class named "balance-text" */
-.balance-text, .custom-class {
+.balance-text,
+.once-custom-selector,
+.continuous-custom-selector {
 	text-wrap: balanced;
 }
 </style>
@@ -49,7 +51,8 @@
          A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g <span class="color-mark">h i j k l m n o p q r s t u v w x y z</span> 0 1 2 3 4 5 6 7 8 9</p>
       <p class="balance-text"><strong>FONT-SIZE TEST:</strong> Lorem ipsum dolor sit amet, <strong>consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore</strong> et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. <strong>Excepteur sint occaecat cupidatat non proident,</strong> sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
       <p class="balance-text">INLINE CONTENT TEST: Lorem ipsum dolor sit amet, consectetur adipisicing <img src="mammoth.jpg" width="28" height="18" /> elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex <img src="mammoth.jpg" width="28" height="18" /> ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
-      <p class="custom-class">MANUALLY TRIGGERED TEST: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+      <p class="continuous-custom-selector">CUSTOM SELECTOR TEST, CONTINUOUS: <code>$.balanceText('.selector');</code> This will keep track of new and old elements with the <code>selector</code> class exactly like the default <code>balance-text</code> class. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+      <p class="once-custom-selector">CUSTOM SELECTOR TEST, ONE-TIME: <code>$('.selector').balanceText();</code> This will be "balanced" only when the developer calls <code>.balanceText()</code>, so they have to track resizing manually.. Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
       <p class="balance-text">ESCAPED MARKUP TEST&lt;u&gt; Escaped HTML Test Here! &lt;/u&gt;</p>
       <p>&nbsp;</p>
       <p>&nbsp;</p>
@@ -65,7 +68,8 @@
   </section>
 </div>
 
-<script>$(".custom-class").balanceText();</script>
+<script>$(".once-custom-selector").balanceText();</script>
+<script>$.balanceText(".continuous-custom-selector");</script>
 
 </body>
 </html>


### PR DESCRIPTION
`$(elements).balanceText()` is meant to only apply it once on the current selection.
`$.balanceText(elementsOrSelector)` watches the selection and applies it continuously.

Replaces #62