### PR TITLE
jQuery 3 no longer supports .selector

### DIFF
--- a/jquery.balancetext.js
+++ b/jquery.balancetext.js
@@ -282,7 +282,7 @@
     $.fn.balanceText = function (skipResize) {
         var selector = this.selector;
 
-        if (!skipResize && balancedElements.indexOf(selector) === -1) {
+        if (!skipResize && selector && balancedElements.indexOf(selector) === -1) {
             // record the selector so we can re-balance it on resize
             balancedElements.push(selector);
         }

--- a/test/test2.htm
+++ b/test/test2.htm
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="content-type" content="text/html; charset=UTF-8">
+<meta charset="utf-8">
+<title>Balance Text - Test 2</title>
+<script src="http://use.edgefonts.net/source-sans-pro:n3,n4,i3,i4,n6.js"></script>
+<script src="http://code.jquery.com/jquery-3.0.0.min.js"></script>
+<script src="../jquery.balancetext.js"></script>
+<link rel="stylesheet" type="text/css" href="test1.css">
+<!--[if lt IE 9]>
+<script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
+<![endif]-->
+
+<style type="text/css">
+/* Apply (proposed) CSS style. Plugin looks for elements with class named "balance-text" */
+.balance-text, .custom-class {
+	text-wrap: balanced;
+}
+</style>
+
+</head>
+
+<body>
+<div id="content">
+  <section id="balanced">
+    <header><h2>Balanced text</h2></header>
+    <div class="demo-body">
+      <p class="balance-text">A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z 0 1 2 3 4 5 6 7 8 9
+         A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z 0 1 2 3 4 5 6 7 8 9</p>
+      <p class="balance-text test-align-justify">TEXT-ALIGN:JUSTIFY TEST: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+      <figure class="picContainer">
+        <img src="mammoth.jpg" width="360" height="232" />
+        <figcaption class="balance-text">Captions are a common usage case. <span style="font-weight:bold">Note</span> that width of caption is constrained to width of image.</figcaption>
+      </figure>
+      <blockquote class="balance-text">Blockquotes are another type of text formatting that may benefit from text balancing.</blockquote>
+      <form action="" method="post" name="form2">
+        <fieldset>
+          <legend>Example of a form label:</legend>
+          <div class="input">
+            <label for="text2" class="balance-text">Right-aligned text can <em>also</em> look bad</label>
+            <input type="text" name="text2" id="text2"/>
+          </div>
+          <input type="submit" name="submit" value="Submit">
+        </fieldset>
+      </form>
+      <p class="balance-text test-line-height">LINE HEIGHT TEST: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+      <p class="balance-text"><span class="color-mark">NESTED TAGS TEST:</span> A B C D E F G H I J K L M N O <span class="color-mark">P Q R S T U V W X Y Z a b c d e f g h i j k l m n o p q r s t u v w x y z 0 1 2 3 4</span> 5 6 7 8 9
+         A B C D E F G H I J K L M N O P Q R S T U V W X Y Z a b c d e f g <span class="color-mark">h i j k l m n o p q r s t u v w x y z</span> 0 1 2 3 4 5 6 7 8 9</p>
+      <p class="balance-text"><strong>FONT-SIZE TEST:</strong> Lorem ipsum dolor sit amet, <strong>consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore</strong> et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. <strong>Excepteur sint occaecat cupidatat non proident,</strong> sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+      <p class="balance-text">INLINE CONTENT TEST: Lorem ipsum dolor sit amet, consectetur adipisicing <img src="mammoth.jpg" width="28" height="18" /> elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex <img src="mammoth.jpg" width="28" height="18" /> ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+      <p class="custom-class">MANUALLY TRIGGERED TEST: Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+      <p class="balance-text">ESCAPED MARKUP TEST&lt;u&gt; Escaped HTML Test Here! &lt;/u&gt;</p>
+      <p>&nbsp;</p>
+      <p>&nbsp;</p>
+      <p>&nbsp;</p>
+      <p>&nbsp;</p>
+      <p>&nbsp;</p>
+      <p>&nbsp;</p>
+      <p>&nbsp;</p>
+      <p>&nbsp;</p>
+      <p>&nbsp;</p>
+      <p><a id="anchor1"></a>Text with anchor.</p>
+    </div>
+  </section>
+</div>
+
+<script>$(".custom-class").balanceText();</script>
+
+</body>
+</html>


### PR DESCRIPTION
This is a partial for #82 

This fixes rendering of `balance-text` class for jQuery 3. Custom selector rendering is not fixed because it requires breaking `balanceText(skipResize)` API, so it will be fixed in version 2.