### PR TITLE
jQuery 3 no longer supports .selector

### DIFF
--- a/jquery.balancetext.js
+++ b/jquery.balancetext.js
@@ -282,7 +282,7 @@
     $.fn.balanceText = function (skipResize) {
         var selector = this.selector;
 
-        if (!skipResize && balancedElements.indexOf(selector) === -1) {
+        if (!skipResize && selector && balancedElements.indexOf(selector) === -1) {
             // record the selector so we can re-balance it on resize
             balancedElements.push(selector);
         }


### PR DESCRIPTION
This is a partial for #82 

This fixes rendering of `balance-text` class for jQuery 3. Custom selector rendering is not fixed because it requires breaking `balanceText(skipResize)` API, so it will be fixed in version 2.