### PR TITLE
!important for the temporary settings

### DIFF
--- a/jquery.balancetext.js
+++ b/jquery.balancetext.js
@@ -327,10 +327,10 @@
 
             // temporary settings
             $this.css({
-                'white-space': 'nowrap',
-                'float': 'none',
-                'display': 'inline',
-                'position': 'static'
+                'white-space': 'nowrap!important',
+                'float': 'none!important',
+                'display': 'inline!important',
+                'position': 'static!important'
             });
 
             var nowrapWidth = $this.width();


### PR DESCRIPTION
I was trying to catch this bug for quite a while.
I noticed balanceText was adding a `<br>` at the beginning of the text, which caused problems with layout.
It turned out that my CSS was overriding the balanceText's temporary settings.

Even though balanceText applies inline styles, our styles had `!important` statements (due to widget nature of the product we're developing). So our CSS had higher specificity particularly for `display: block`.

The proposed change will ensure the highest specificity for balanceText's temporary CSS which should prevent bugs in similar cases.