### PR TITLE
Remove old broken IE8 polyfill

### DIFF
--- a/test/interface.htm
+++ b/test/interface.htm
@@ -11,9 +11,6 @@
 <script src="https://use.edgefonts.net/source-sans-pro:n3,n4,i3,i4,n6.js"></script>
 <script src="../balancetext.js"></script>
 <link rel="stylesheet" type="text/css" href="test1.css">
-<!--[if lt IE 9]>
-<script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-<![endif]-->
 
 <style type="text/css">
 /* Apply (proposed) CSS style. Plugin looks for elements with class named "balance-text" */

--- a/test/test-watch-unwatch.htm
+++ b/test/test-watch-unwatch.htm
@@ -8,9 +8,6 @@
 <script>
   balanceText();
 </script>
-<!--[if lt IE 9]>
-<script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-<![endif]-->
 
 <style type="text/css">
 /* Apply (proposed) CSS style. Plugin looks for elements with class named "balance-text" */

--- a/test/test-wordbreaking.htm
+++ b/test/test-wordbreaking.htm
@@ -10,9 +10,6 @@
   balanceText();
 </script>
 <link rel="stylesheet" type="text/css" href="test-wordbreaking.css">
-<!--[if lt IE 9]>
-<script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-<![endif]-->
 
 <style type="text/css">
 /* Apply (proposed) CSS style. Plugin looks for elements with class named "balance-text" */

--- a/test/test1.htm
+++ b/test/test1.htm
@@ -10,9 +10,6 @@
   balanceText();
 </script>
 <link rel="stylesheet" type="text/css" href="test1.css">
-<!--[if lt IE 9]>
-<script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
-<![endif]-->
 
 <style type="text/css">
 /* Apply (proposed) CSS style. Plugin looks for elements with class named "balance-text" */


### PR DESCRIPTION
## Description

Remove old broken IE8 polyfill in HTML pages

## Motivation and Context

IE8 and earlier are no longer supported
